### PR TITLE
clean manifest

### DIFF
--- a/session-manager/src/main/AndroidManifest.xml
+++ b/session-manager/src/main/AndroidManifest.xml
@@ -1,13 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-
-          package="hundredthirtythree.sessionmanager"
->
-
-    <application android:allowBackup="false"
-                 android:label="@string/app_name"
-                 android:supportsRtl="true"
-    >
-
-    </application>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    package="hundredthirtythree.sessionmanager">
 
 </manifest>

--- a/session-manager/src/main/res/values/strings.xml
+++ b/session-manager/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">SessionManager</string>
-</resources>


### PR DESCRIPTION
there is no need to have those lines in the libraries manifest, it just forces people to override the name in the app